### PR TITLE
added GUI "support" for OS X El Capitan 10.11

### DIFF
--- a/packal-controller-script.php
+++ b/packal-controller-script.php
@@ -31,7 +31,9 @@ if ( $q == 'open-gui' ) {
 
 
 	// Start the webserver
-	if ( ( strpos( $osx, '10.9' ) !== FALSE ) || ( strpos( $osx, '10.10' ) !== FALSE ) ) {
+	if ( ( strpos( $osx, '10.9' ) !== FALSE ) 
+	    || ( strpos( $osx, '10.10' ) !== FALSE ) 
+	    || ( strpos( $osx, '10.11' ) !== FALSE ) ) {
 		// Since we're using Mavericks, we can just use the native php 5.4 binary.
 		exec( "nohup php -S localhost:7893 -t gui/ > /dev/null 2>&1 &" );
 	} else {

--- a/script.php
+++ b/script.php
@@ -20,7 +20,7 @@ if ( ! ini_get('date.timezone') ) {
 $osx = exec( "sw_vers | grep 'ProductVersion:' | grep -o '10\.[0-9]*'" );
 
 // So, they can use the GUI if they're using Mavericks or Yosemite.
-if ( ( $osx == '10.9') || ( $osx == '10.10' ) )
+if ( ( $osx == '10.9') || ( $osx == '10.10' ) || ( $osx == '10.11' ) )
   $gui = TRUE;
 
 firstRun();


### PR DESCRIPTION
The conditional that prevented the GUI on versions before 10.9 also prevented the GUI on El Capitan. The change doesn't appear to have any side effects and the GUI runs as well as it ever has. This change may be unnecessary if 2.0 is coming soon.
Thank you