### PR TITLE
Fix: Array to String conversion error on PHP7x

### DIFF
--- a/cli/packal.php
+++ b/cli/packal.php
@@ -41,9 +41,11 @@ function getOption( $opt = array() ) {
 	$config = simplexml_load_file( $config );
 
 	if ( isset( $opt[1] ) && ( $opt[1] == true ) ) {
-		return $config->$opt[0];
+		$prop = $opt[0];
+		return $config->{$prop};
 	}
-	echo $config->$opt[0];
+	$prop = $opt[0];
+	echo $config->{$prop};
 
 }
 


### PR DESCRIPTION
There was an issue with the updater, I guess for the ones running a recent PHP, which caused the update to exit with errors . This fixes part of the issue as there is one more in plist-migration.php regarding a missing index for keyword, around line 68.